### PR TITLE
Add support for `--no-increment` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "concat-stream": "^2.0.0",
     "conventional-changelog": "^3.1.8",
     "conventional-recommended-bump": "^5.0.0",
+    "git-semver-tags": "^3.0.0",
     "prepend-file": "^1.3.1",
     "release-it": "^12.3.0"
   },


### PR DESCRIPTION
## Why this PR

I test a lot of tools for automate my releasing pipeline in our CI, but lot of them are not very plug-gable and aren't design for CI. Release-it tool is a very good tool, I spend a lot of time to audit some of the codebase.

My workflow is
1. Merge a PR
1. Trigger generate a release in CI
1. the CI commit and push version number and CHANGELOG.md
1. then it trigger a second pipeline for building the release (tar.gz, docker image)
1. then I need to publish the builded assets to a Gitlab Release

## What this PR fix
My usecase didn't work because the `--no-increment` option wasn't compatible with `conventional-changelog` plugin.

## TODO

Re-generate the CHANGELOG infile not implemented, like `releaseCount` option [here](
https://github.com/conventional-changelog/releaser-tools/blob/5dea83046f1874f6973891dd5663165980875b9b/packages/conventional-gitlab-releaser/src/index.js#L40-L66)

## My configuration samples
### First step commit/push version + npm bump
`release-it --config step1.js --ci`

```js
{
  git: {
    requireCommits: true,
    push: true,
    commitMessage: 'chore(release): release v${version}',
    tagName: 'v${version}',
    tagAnnotation: 'Release v${version}',
  },
  plugins: {
    "@release-it/conventional-changelog": {
      preset: "angular",
      infile: "CHANGELOG.md"
    }
  },
  gitlab: {
    release: false
  }
}
```
### Second step publish assets on Gitlab with the good changelog
`release-it --config step2.js --ci --no-increment`

```js
{
  git: {
    commit: false,
  },
  plugins: {
    "@release-it/conventional-changelog": {
      preset: "angular",
    }
  },
  gitlab: {
    release: true,
    assets: [
      './test.tar.gz'
    ]
  }
}
```