### PR TITLE
fix: --release-version not working if conventional-changelog is enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,10 @@ class ConventionalChangelog extends Plugin {
     return ignoreRecommendedBump ? null : this.getRecommendedVersion(options);
   }
 
+  getIncrementedVersionCI(options) {
+    return this.getIncrementedVersion(options)
+  }
+
   async bump(version) {
     const recommendedVersion = this.getContext('version');
 


### PR DESCRIPTION
Currently `--release-version` shows release version from `Version` plugin. When `conventional-changelog` plugin is enabled `Version` plugin is disabled. So I added a `getIncrementedVersionCI()` function to `conventional-changelog`.