### PR TITLE
Properly bump version when latestVersion is not set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,0 @@
-The changelog
-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,2 @@
+The changelog
+

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class ConventionalChangelog extends Plugin {
   }
 
   async getChangelog(latestVersion) {
+    if (latestVersion === null) latestVersion = '0.0.0'
     if (!this.config.isIncrement) {
       this.setContext({ version: latestVersion });
     } else {


### PR DESCRIPTION
This fix resolves #23. 

Since the built-in `version` plug-in is skipped when `ignoreRecommendedBump` is set to `false`, repositories that have not been previously versioned do not have the `latestVersion` value set. 
