### PR TITLE
Pass 'parserOpts' and 'writerOpts' to conventional-changelog-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,46 @@ For example, you can use the following option to include merge commits into chan
 }
 ```
 
+### `writerOpts`
+
+Default value: `undefined`
+
+Options for
+[`conventional-commits-parser`](https://github.com/conventional-changelog-archived-repos/conventional-commits-parser#api).
+For example, you can use the following option to group the commits by 'scope' instead of 'type' by default.
+
+```json
+{
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "writerOpts": {
+        "groupBy:" "scope"
+      }
+    }
+  }
+}
+```
+
+### `parserOpts`
+
+Default value: `undefined`
+
+Options for
+[`conventional-commits-parser`](https://github.com/conventional-changelog-archived-repos/conventional-commits-parser#api).
+For example, you can use the following option to set the merge pattern during parsing commit message:
+
+```json
+{
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "parserOpts": {
+        "mergePattern": /^Merge pull request #(\d+) from (.*)$/
+      }
+    }
+  }
+}
+```
+
 ## GitHub Actions
 
 When using this plugin in a GitHub Action, make sure to set

--- a/README.md
+++ b/README.md
@@ -123,12 +123,32 @@ For example, you can use the following option to include merge commits into chan
 }
 ```
 
+### `parserOpts`
+
+Default value: `undefined`
+
+Options for
+[`conventional-commits-parser`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#api).
+For example, you can use the following option to set the merge pattern during parsing the commit message:
+
+```json
+{
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "parserOpts": {
+        "mergePattern": /^Merge pull request #(\d+) from (.*)$/
+      }
+    }
+  }
+}
+```
+
 ### `writerOpts`
 
 Default value: `undefined`
 
 Options for
-[`conventional-commits-parser`](https://github.com/conventional-changelog-archived-repos/conventional-commits-parser#api).
+[`conventional-changelog-writer`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-writer#api).
 For example, you can use the following option to group the commits by 'scope' instead of 'type' by default.
 
 ```json
@@ -137,26 +157,6 @@ For example, you can use the following option to group the commits by 'scope' in
     "@release-it/conventional-changelog": {
       "writerOpts": {
         "groupBy:" "scope"
-      }
-    }
-  }
-}
-```
-
-### `parserOpts`
-
-Default value: `undefined`
-
-Options for
-[`conventional-commits-parser`](https://github.com/conventional-changelog-archived-repos/conventional-commits-parser#api).
-For example, you can use the following option to set the merge pattern during parsing commit message:
-
-```json
-{
-  "plugins": {
-    "@release-it/conventional-changelog": {
-      "parserOpts": {
-        "mergePattern": /^Merge pull request #(\d+) from (.*)$/
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -69,10 +69,13 @@ class ConventionalChangelog extends Plugin {
     const context = Object.assign({ version, previousTag, currentTag }, this.options.context);
     const debug = this.config.isDebug ? this.debug : null;
     const gitRawCommitsOpts = Object.assign({ debug }, this.options.gitRawCommitsOpts);
+    const { parserOpts, writerOpts } = options
     delete options.context;
     delete options.gitRawCommitsOpts;
-    this.debug('conventionalChangelog', { options, context, gitRawCommitsOpts });
-    return conventionalChangelog(options, context, gitRawCommitsOpts);
+    delete options.parserOpts;
+    delete options.writerOpts;
+    this.debug('conventionalChangelog', { options, context, gitRawCommitsOpts, parserOpts, writerOpts });
+    return conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, writerOpts);
   }
 
   generateChangelog(options) {

--- a/test.js
+++ b/test.js
@@ -191,7 +191,7 @@ test('should pass only parserOpts', async t => {
 test('should pass only writerOpts', async t => {
   conventionalChangelog.resetHistory();
   const writerOpts = {
-    groupBy: 'type'
+    groupBy: 'scope'
   };
   const options = { [namespace]: { preset, writerOpts } };
   const plugin = factory(Plugin, { namespace, options });
@@ -202,7 +202,7 @@ test('should pass only writerOpts', async t => {
   assert.deepStrictEqual(args[2], { debug: null });
   assert.deepStrictEqual(args[3], undefined)
   assert.deepStrictEqual(args[4], {
-    groupBy: 'type'
+    groupBy: 'scope'
   });
 });
 

--- a/test.js
+++ b/test.js
@@ -167,3 +167,66 @@ test('should not write infile in dry run', async t => {
   assert.strictEqual(spy.callCount, 0);
   assert.throws(() => fs.readFileSync(infile), /no such file/);
 });
+
+test('should pass only parserOpts', async t => {
+  conventionalChangelog.resetHistory();
+  const parserOpts = {
+    mergePattern: /^Merge pull request #(\d+) from (.*)$/,
+    mergeCorrespondence: ['id', 'source']
+  };
+  const options = { [namespace]: { preset, parserOpts } };
+  const plugin = factory(Plugin, { namespace, options });
+  await runTasks(plugin);
+  const args = conventionalChangelog.args[0];
+  assert.deepStrictEqual(args[0], { releaseCount: 1, preset: 'angular', tagPrefix: '' });
+  assert.deepStrictEqual(args[1], { version: '1.1.0', currentTag: null, previousTag: undefined });
+  assert.deepStrictEqual(args[2], { debug: null });
+  assert.deepStrictEqual(args[3], {
+    mergePattern: /^Merge pull request #(\d+) from (.*)$/,
+    mergeCorrespondence: ['id', 'source']
+  });
+  assert.deepStrictEqual(args[4], undefined)
+});
+
+test('should pass only writerOpts', async t => {
+  conventionalChangelog.resetHistory();
+  const writerOpts = {
+    groupBy: 'type'
+  };
+  const options = { [namespace]: { preset, writerOpts } };
+  const plugin = factory(Plugin, { namespace, options });
+  await runTasks(plugin);
+  const args = conventionalChangelog.args[0];
+  assert.deepStrictEqual(args[0], { releaseCount: 1, preset: 'angular', tagPrefix: '' });
+  assert.deepStrictEqual(args[1], { version: '1.1.0', currentTag: null, previousTag: undefined });
+  assert.deepStrictEqual(args[2], { debug: null });
+  assert.deepStrictEqual(args[3], undefined)
+  assert.deepStrictEqual(args[4], {
+    groupBy: 'type'
+  });
+});
+
+test('should pass parserOpts and writerOpts', async t => {
+  conventionalChangelog.resetHistory();
+  const parserOpts = {
+    mergePattern: /^Merge pull request #(\d+) from (.*)$/,
+    mergeCorrespondence: ['id', 'source']
+  };
+  const writerOpts = {
+    groupBy: 'type'
+  };
+  const options = { [namespace]: { preset, parserOpts, writerOpts } };
+  const plugin = factory(Plugin, { namespace, options });
+  await runTasks(plugin);
+  const args = conventionalChangelog.args[0];
+  assert.deepStrictEqual(args[0], { releaseCount: 1, preset: 'angular', tagPrefix: '' });
+  assert.deepStrictEqual(args[1], { version: '1.1.0', currentTag: null, previousTag: undefined });
+  assert.deepStrictEqual(args[2], { debug: null });
+  assert.deepStrictEqual(args[3], {
+    mergePattern: /^Merge pull request #(\d+) from (.*)$/,
+    mergeCorrespondence: ['id', 'source']
+  });
+  assert.deepStrictEqual(args[4], {
+    groupBy: 'type'
+  });
+});


### PR DESCRIPTION
This fix resolves https://github.com/release-it/conventional-changelog/issues/31

# The intent is to pass both parserOpts and writerOpts to conventional-changelog-core