### PR TITLE
Support page header setting of changelog file

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,8 +90,18 @@ class ConventionalChangelog extends Plugin {
     });
   }
 
-  async writeChangelog() {
+  getOldChangelog() {
     const { infile } = this.options;
+    return new Promise((resolve, reject) => {
+      const readStream = fs.createReadStream(infile);
+      const resolver = result => resolve(result.toString().trim());
+      readStream.pipe(concat(resolver));
+      readStream.on('error', reject);
+    });
+  }
+
+  async writeChangelog() {
+    const { infile, header } = this.options;
     let { changelog } = this.config.getContext();
 
     let hasInfile = false;
@@ -102,12 +112,20 @@ class ConventionalChangelog extends Plugin {
       this.debug(err);
     }
 
+    let oldChangelog = ""
+    try{
+      oldChangelog = await this.getOldChangelog();
+      oldChangelog = oldChangelog.replace(new RegExp(EOL, 'g'), '\n').replace(header, '');
+    }catch(err){
+      this.debug(err);
+    }
+
     if (!hasInfile) {
       changelog = await this.generateChangelog({ releaseCount: 0 });
       this.debug({ changelog });
     }
 
-    await prependFile(infile, changelog + EOL + EOL);
+    fs.writeFileSync(infile, header + EOL + EOL + changelog + EOL + EOL + oldChangelog);
 
     if (!hasInfile) {
       await this.exec(`git add ${infile}`);

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ class ConventionalChangelog extends Plugin {
     let oldChangelog = ""
     try{
       oldChangelog = await this.getOldChangelog();
-      oldChangelog = oldChangelog.replace(header, '');
+      oldChangelog = oldChangelog.replace(header.split(/\r\n|\r|\n/g).join(EOL), '');
     }catch(err){
       this.debug(err);
     }

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ class ConventionalChangelog extends Plugin {
     let oldChangelog = ""
     try{
       oldChangelog = await this.getOldChangelog();
-      oldChangelog = oldChangelog.replace(new RegExp(EOL, 'g'), '\n').replace(header, '');
+      oldChangelog = oldChangelog.replace(header, '');
     }catch(err){
       this.debug(err);
     }
@@ -125,7 +125,7 @@ class ConventionalChangelog extends Plugin {
       this.debug({ changelog });
     }
 
-    fs.writeFileSync(infile, header + EOL + EOL + changelog + EOL + EOL + oldChangelog);
+    fs.writeFileSync(infile, header + EOL + EOL + changelog + oldChangelog);
 
     if (!hasInfile) {
       await this.exec(`git add ${infile}`);

--- a/test.js
+++ b/test.js
@@ -130,15 +130,16 @@ test('should use provided version', async t => {
 });
 
 test(`should write and update infile (${infile})`, async t => {
-  const options = { [namespace]: { preset, infile }, git };
+  const header = "The header"
+  const options = { [namespace]: { preset, infile, header }, git };
   const plugin = factory(Plugin, { namespace, options });
   await runTasks(plugin);
   const changelog = fs.readFileSync(infile);
-  assert.strictEqual(changelog.toString().trim(), 'The changelog');
+  assert.strictEqual(changelog.toString().trim(), `${header}${EOL}${EOL}The changelog`);
   {
     await runTasks(plugin);
     const changelog = fs.readFileSync(infile);
-    assert.strictEqual(changelog.toString().trim(), `The changelog${EOL}${EOL}The changelog`);
+    assert.strictEqual(changelog.toString().trim(), `${header}${EOL}${EOL}The changelog${EOL}${EOL}The changelog`);
   }
   fs.unlinkSync(infile);
 });


### PR DESCRIPTION
# Why this PR

Because I need to add more custom descriptions to the header of the CHANGELOG file .

The header set in the preset does not take effect. After passing the header settings to the plug-in during the local debugging process, the results obtained are far from expected.

> This PR is reopen of [PR#18](https://github.com/release-it/conventional-changelog/pull/18)

## Expect
The header is only at the top of the page

```md
# Changelog

This document lists breaking changes for each major release.

See the GitHub Releases page for detailed changelogs:
[https://github.com/release-it/release-it/releases](https://github.com/release-it/release-it/releases)

## v14

- Removed `global` property from plugins. Use `this.config[key]` instead.
- Removed deprecated `npm.access` option. Set this in `package.json` instead.

## v13

- Dropped support for Node v8
- Dropped support for GitLab v11.6 and lower.
- Deprecated `scripts` are removed (in favor of [hooks](https://github.com/release-it/release-it#hooks)).
- Removed deprecated `--non-interactive` (`-n`) argument. Use `--ci` instead.
- Removed old `%s` and `[REV_RANGE]` syntax in command substitutions. Use `${version}` and `${latestTag}` instead.

```

## Reality
The header will appear in the top of each version of content changes
```md
# Changelog

This document lists breaking changes for each major release.

See the GitHub Releases page for detailed changelogs:
[https://github.com/release-it/release-it/releases](https://github.com/release-it/release-it/releases)

## v14

- Removed `global` property from plugins. Use `this.config[key]` instead.
- Removed deprecated `npm.access` option. Set this in `package.json` instead.

# Changelog

This document lists breaking changes for each major release.

See the GitHub Releases page for detailed changelogs:
[https://github.com/release-it/release-it/releases](https://github.com/release-it/release-it/releases)

## v13

- Dropped support for Node v8
- Dropped support for GitLab v11.6 and lower.
- Deprecated `scripts` are removed (in favor of [hooks](https://github.com/release-it/release-it#hooks)).
- Removed deprecated `--non-interactive` (`-n`) argument. Use `--ci` instead.
- Removed old `%s` and `[REV_RANGE]` syntax in command substitutions. Use `${version}` and `${latestTag}` instead.

```

# What this PR fix

Increase in the configuration header is provided, at its head and applied to the document output. 

# Configuration samples

```json
{
  "plugins": {
    "@release-it/conventional-changelog": {
      "infile": "CHANGELOG.md",
      "header": "# 📋 更新历史 \n\n",
      "preset": {
        "name": "conventionalcommits"
      }
    }
  }
}
```