### PR TITLE
Unified header line break identifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,8 +101,9 @@ class ConventionalChangelog extends Plugin {
   }
 
   async writeChangelog() {
-    const { infile, header } = this.options;
+    const { infile, header:_header } = this.options;
     let { changelog } = this.config.getContext();
+    const header = _header.split(/\r\n|\r|\n/g).join(EOL)
 
     let hasInfile = false;
     try {
@@ -115,7 +116,7 @@ class ConventionalChangelog extends Plugin {
     let previousChangelog = '';
     try {
       previousChangelog = await this.getPreviousChangelog();
-      previousChangelog = previousChangelog.replace(header.split(/\r\n|\r|\n/g).join(EOL), '');
+      previousChangelog = previousChangelog.replace(header, '');
     } catch (err) {
       this.debug(err);
     }

--- a/test.js
+++ b/test.js
@@ -135,7 +135,7 @@ test(`should write and update infile (${infile})`, async t => {
   const plugin = factory(Plugin, { namespace, options });
   await runTasks(plugin);
   const changelog = fs.readFileSync(infile);
-  assert.strictEqual(changelog.toString().trim(), `${header}${EOL}${EOL}The changelog`);
+  assert.strictEqual(changelog.toString().trim(), `The header${EOL}${EOL}The subheader${EOL}${EOL}The changelog`);
   {
     await runTasks(plugin);
     const changelog = fs.readFileSync(infile);


### PR DESCRIPTION
There will be two headers when the CHANGELOG is updated for the second time under Windows. something like this:

```
The header\n\nThe subheader\r\n\r\nThe changelogThe header\n\nThe subheader\r\n\r\nThe changelog
```

It is found in the code that the EOL conversion is done when replacing the header option, but not when merging the content.

```js
//# https://github.com/release-it/conventional-changelog/blob/master/index.js#L118
previousChangelog = previousChangelog.replace(header.split(/\r\n|\r|\n/g).join(EOL), '');
```

```js
//# https://github.com/release-it/conventional-changelog/blob/master/index.js#L128
fs.writeFileSync(infile, header + EOL + EOL + changelog + previousChangelog);
```

In the header option of the test case, the newline is `\n`. The judgment result uses EOL. To meet the unified newline symbol, convert all kinds of newline characters in the header.

Sorry, these are caused by me, have submitted PR to fix. 😅