### PR TITLE
fix: Add fallback value to `header` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ class ConventionalChangelog extends Plugin {
   }
 
   async writeChangelog() {
-    const { infile, header: _header } = this.options;
+    const { infile, header: _header = '' } = this.options;
     let { changelog } = this.config.getContext();
     const header = _header.split(/\r\n|\r|\n/g).join(EOL);
 


### PR DESCRIPTION
Hello,

There should be the default value for new `header` option, otherwise it's a breaking change, it fails in process:

![failing-screenshot](https://user-images.githubusercontent.com/49679666/157512249-c6a550c5-2398-4a11-87b1-ea2b0c980c0b.jpeg)

Unfortunately, I have no time to investigate why the tests passed without this, but after this fix everything works as before.