### PR TITLE
Fix the parserOpts in the getRecommendedVersion function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class ConventionalChangelog extends Plugin {
     this.debug({ increment, latestVersion, isPreRelease, preReleaseId });
     this.debug('conventionalRecommendedBump', { options });
     return new Promise((resolve, reject) =>
-      conventionalRecommendedBump(options, (err, result) => {
+      conventionalRecommendedBump(options, options?.parserOpts, (err, result) => {
         this.debug({ err, result });
         if (err) return reject(err);
         let { releaseType } = result;


### PR DESCRIPTION
In order to make `conventionalRecommendedBump(options, [parserOpts,] callback)` receive the param parseOpts, it has to be included in the getRecommendedVersion call, if not, it is ignored and it does not detect the correct commitType when parserOpts are passed in the plugin configuration, for example:

_release-it config_
`{
"@release-it/conventional-changelog":{
preset:"angular",
parserOpts: {
        headerPattern: /^(\S*) (\w*)(?:\(([\w$.\-* ]*)\))?: (.*)$/,
        headerCorrespondence: ['emoji', 'type', 'scope', 'subject'],
         },
}
}`
 
         
_commits_
'🆕 feat: Some new features'
         
Before this pr: 
commitType = 'patch'

After this pr:
commitType = 'minor'