### PR TITLE
chore: bump use caret to get `semver` minor version, fixes #67

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "concat-stream": "^2.0.0",
     "conventional-changelog": "^4.0.0",
     "conventional-recommended-bump": "^7.0.1",
-    "semver": "7.5.1"
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "bron": "^2.0.2",


### PR DESCRIPTION
- I'm not sure why it was using a fixed version, but I assumed it was a possible typo or an old fix and we should be good to update
- fixes #67