### PR TITLE
Fix tag prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ class ConventionalChangelog extends Plugin {
   }
 
   getInitialOptions(options, namespace) {
-    const tagName = options.git ? options.git.tagName : null;
-    options[namespace].tagPrefix = tagName ? tagName.replace(/v?\$\{version\}$/, '') : '';
+    const { tagPrefix, tagName }  = options.git ?? {};
+    const tagNameNoVersion = tagName ? tagName.replace(/v?\$\{version\}$/, '') : '';
+    options[namespace].tagPrefix = tagPrefix ?? tagNameNoVersion;
     return options[namespace];
   }
 

--- a/index.js
+++ b/index.js
@@ -36,8 +36,14 @@ class ConventionalChangelog extends Plugin {
     const { options } = this;
     this.debug({ increment, latestVersion, isPreRelease, preReleaseId });
     this.debug('conventionalRecommendedBump', { options });
+    let { tagPrefix } = options
+    const npmName = this.config.getContext('npm.name')
+    if (tagPrefix && npmName) {
+      tagPrefix = tagPrefix.replace(/\$\{npm\.name\}/, npmName)
+    }
+    const updatedOptions = { ...options, tagPrefix }
     try {
-      const result = await conventionalRecommendedBump(options, options?.parserOpts);
+      const result = await conventionalRecommendedBump(updatedOptions, options?.parserOpts);
       this.debug({ result });
       let { releaseType } = result;
       if (increment) {


### PR DESCRIPTION
Addresses [the issues raised here](https://github.com/release-it/conventional-changelog/issues/80). 

Two fixes to the functioning of `tagPrefix`:

- If the `tagPrefix` option is explicitly given in settings, don't override it with the derived prefix from `tagName`.
- If the `${npm.name}` variable is present in `tagPrefix`, interpolate it's value before passing through to `conventional-recommended-bump`

Caveats:

- Does not address interpolating any other variable except `npm.name` (which presumably would be much less common in `tagPrefix`) - I'm not familiar enough with the `release-it` architecture to see how to do this well.

- These are conservative changes in that they shouldn't affect people not trying to use these options/variables.