### PR TITLE
fix: handle pre-release version properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "concat-stream": "^2.0.0",
     "conventional-changelog": "^5.1.0",
     "conventional-recommended-bump": "^9.0.0",
-    "semver": "^7.6.2"
+    "semver": "^7.6.2",
+    "git-semver-tags": "^7.0.0"
   },
   "devDependencies": {
     "bron": "^2.0.3",


### PR DESCRIPTION
Fixes https://github.com/release-it/conventional-changelog/issues/90

The solution is inspired from https://github.com/release-it/conventional-changelog/pull/92 but simplified and with unit tests.