### PR TITLE
feat: update conventional config

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "concat-stream": "^2.0.0",
-    "conventional-changelog": "^5.1.0",
-    "conventional-recommended-bump": "^9.0.0",
+    "conventional-changelog": "^6.0.0",
+    "conventional-recommended-bump": "^10.0.0",
     "git-semver-tags": "^8.0.0",
     "semver": "^7.6.3"
   },


### PR DESCRIPTION
## Description

Took a swing at upgrading `conventional-config` and `conventional-recommended-bump`.
`conventional-config` was a pretty easy upgrade - almost nothing has changed there.
It was a bit more tricky with `conventional-recommended-bump` as they've changed API completely. In every case there is a (undocumented) migration path though. In this PR I took the direction of rewriting the "old API" to new one within the library so the migration for `@release-it/conventional-changelog` users would be as easy as possible.

But honestly? Looking at this now, I think there should be a breaking change introduced in `@release-it/conventional-changelog` to redo the options passed to the plugin. New API could look like this:
```ts
{
  commits: { /* options for bumper.commits */ },
  preset: { /* options for bumper.preset */ },
  tag: { /* options for bumper.tag */ },
  whatBump,
}
```

After doing this change it would be pretty easy to write a simple migration docs and say which old options go where in the new API - it's clearly visible in this PR.

By doing this `@release-it/conventional-commits` will remain as transparent as possible - it'll still just pass options to underlying APIs.


But, in the end it's your decision @webpro, so feel free to continue with this migration as you think is best.

Cheers ✌️ 


### Resolves
https://github.com/release-it/conventional-changelog/issues/88
