### PR TITLE
Ensure version is valid before passing it to semver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+node_modules

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ class ConventionalChangelog extends Plugin {
           skipUnstable: true
         });
 
-        const lastStableTag = tags.length > 0 ? tags[0] : null;
+        const lastStableTag = tags.length > 0 ? tags[0].replace(options.tagPrefix, '') : null;
 
         if (
           lastStableTag &&

--- a/test.js
+++ b/test.js
@@ -189,6 +189,34 @@ test('should follow conventional commit strategy with prereleaase', async t => {
   assert.equal(version4, '2.0.0-alpha.1');
 });
 
+test.only('should follow conventional commit strategy with prereleaase and custom prefix', async t => {
+  setup();
+  const prefix = 'scope/';
+  sh.exec(`git tag ${prefix}v1.2.1`);
+  add('feat', 'baz');
+
+  const [config, container] = getOptions({ preset: { name: 'conventionalcommits' } }, { commit: true, tag: true });
+  config.preRelease = 'alpha';
+  config.git.tagName = `${prefix}v${'${version}'}`;
+  const { version: version1 } = await runTasks(config, container);
+  assert.equal(version1, '1.3.0-alpha.0');
+
+  add('fix', 'buz');
+
+  const { version: version2 } = await runTasks(config, container);
+  assert.equal(version2, '1.3.0-alpha.1');
+
+  add('feat', 'biz', { breaking: true });
+
+  const { version: version3 } = await runTasks(config, container);
+  assert.equal(version3, '2.0.0-alpha.0');
+
+  add('fix', 'boz');
+
+  const { version: version4 } = await runTasks(config, container);
+  assert.equal(version4, '2.0.0-alpha.1');
+});
+
 test('should use provided pre-release id (pre-release continuation)', async t => {
   setup();
   sh.exec(`git tag 1.0.1-alpha.0`);


### PR DESCRIPTION
There is a use case when using a custom tagPrefix.
In my monorepo I'm trying to implement semver prerelease flow with a custom prefix like so:

`<app>/v<semver>-alfa.0 -> <app>/v<semver>-alfa.1 -> <app>/v<semver>-beta.0 -> <app>/v<semver>`

It works fine till first stable version is created. After this new pre-release ones are failing as tags are technically invalid according to semver.

This PR attempts to address this issue.

I'd be happy to discard it if there is an existing way to address this.