### PR TITLE
Migrate to conventional-changelog v6 + conventional-recommended-bump v10

### DIFF
--- a/.github/workflows/publish-pkg.pr.new.yml
+++ b/.github/workflows/publish-pkg.pr.new.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           node-version: 22
 
-      - run: npx pkg-pr-new publish
+      - run: npx pkg-pr-new publish --compact

--- a/.github/workflows/publish-pkg.pr.new.yml
+++ b/.github/workflows/publish-pkg.pr.new.yml
@@ -1,0 +1,24 @@
+name: Publish with pkg.pr.new
+
+on:
+  pull_request:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '!**'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npx pkg-pr-new publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
     name: ${{ matrix.os }} (Node v${{ matrix.node }})
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ Options are passed verbatim to
 and
 [conventional-changelog-core](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#api).
 
+### Contents
+
+- [`infile`](#infile)
+- [`header`](#header)
+- [`ignoreRecommendedBump`](#ignorerecommendedbump)
+- [`strictSemVer`](#strictsemver)
+- [`preset`](#preset)
+- [`context`](#context)
+- [`gitRawCommitsOpts`](#gitrawcommitsopts)
+- [`parserOpts`](#parseropts)
+- [`writerOpts`](#writeropts)
+- [`bumperCommitsOpts`](#bumpercommitsopts)
+- [`bumperTagOpts`](#bumpertagopts)
+- [`bumperParserOpts`](#bumperparseropts)
+
 ### `preset`
 
 Use one of:
@@ -68,6 +83,9 @@ Use an object with `name` and `types` to use a custom preset:
 See the
 [Conventional Changelog Configuration Spec (v2.1.0)](https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.1.0/README.md)
 for the configuration object to pass as `preset`.
+
+This is also passed as the first argument to
+[`bumper.loadPreset`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api).
 
 ### `infile`
 
@@ -212,6 +230,21 @@ module.exports = {
   }
 };
 ```
+
+### `bumperTagOpts`
+
+This option will be passed as the first argument to
+[`bumper.tag`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
+
+### `bumperCommitsOpts`
+
+This option will be passed as the first argument to
+[`bumper.commits`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
+
+### `bumperParserOpts`
+
+This option will be passed as the second argument to
+[`bumper.parserOptions`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
 
 ## Command-line
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ and
 - [`bumperCommitsOpts`](#bumpercommitsopts)
 - [`bumperTagOpts`](#bumpertagopts)
 - [`bumperParserOpts`](#bumperparseropts)
+- [`whatBump`](#whatbump)
 
 ### `preset`
 
@@ -245,6 +246,11 @@ This option will be passed as the first argument to
 
 This option will be passed as the second argument to
 [`bumper.parserOptions`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
+
+### `whatBump`
+
+This option will be passed as the first argument to
+[`bumper.bump`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
 
 ## Command-line
 

--- a/README.md
+++ b/README.md
@@ -21,30 +21,31 @@ In the [release-it](https://github.com/release-it/release-it) config, for exampl
 }
 ```
 
-Options are passed verbatim to
-[conventional-recommended-bump](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump#readme)
-and
-[conventional-changelog-core](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#api).
+The plugin is a wrapper around conventional-changelog packages
+[conventional-recommended-bump](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump#readme),
+[conventional-changelog-core](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#api)
+and more.
 
-### Contents
+## Contents
 
-- [`infile`](#infile)
-- [`header`](#header)
-- [`ignoreRecommendedBump`](#ignorerecommendedbump)
-- [`strictSemVer`](#strictsemver)
 - [`preset`](#preset)
-- [`context`](#context)
-- [`gitRawCommitsOpts`](#gitrawcommitsopts)
-- [`parserOpts`](#parseropts)
-- [`writerOpts`](#writeropts)
-- [`bumperCommitsOpts`](#bumpercommitsopts)
-- [`bumperTagOpts`](#bumpertagopts)
-- [`bumperParserOpts`](#bumperparseropts)
-- [`whatBump`](#whatbump)
+- Bump
+  - [`commitsOpts`](#commitsopts)
+  - [`tagOpts`](#tagopts)
+  - [`whatBump`](#whatbump)
+  - [`ignoreRecommendedBump`](#ignorerecommendedbump)
+  - [`strictSemVer`](#strictsemver)
+- Changelog
+  - [`infile`](#infile)
+  - [`header`](#header)
+  - [`context`](#context)
+  - [`gitRawCommitsOpts`](#gitrawcommitsopts)
+  - [`parserOpts`](#parseropts)
+  - [`writerOpts`](#writeropts)
 
 ### `preset`
 
-Use one of:
+For `preset.name`, use one of:
 
 - `angular`
 - `atom`
@@ -81,12 +82,55 @@ Use an object with `name` and `types` to use a custom preset:
 }
 ```
 
+This is passed as the first argument to
+[`bumper.loadPreset`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
+(in both bumper and changelog writer).
+
 See the
 [Conventional Changelog Configuration Spec (v2.1.0)](https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.1.0/README.md)
 for the configuration object to pass as `preset`.
 
-This is also passed as the first argument to
-[`bumper.loadPreset`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api).
+## Bump
+
+### `tagOpts`
+
+- This option will be passed as the first argument to
+  [`bumper.tag`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
+- [Type definition for `tagOpts` → look for `GetSemverTagsParams`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/git-client/src/types.ts)
+
+### `commitsOpts`
+
+- This option will be passed as the first argument to
+  [`bumper.commits`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
+- [Type definition for `commitsOpts` → look for `GetCommitsParams`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/git-client/src/types.ts)
+
+### `whatBump`
+
+- This option will be passed as the first argument to
+  [`bumper.bump`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
+- [Type definition for `whatBump` → look for `Preset['whatBump']`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/src/types.ts)
+
+### `ignoreRecommendedBump`
+
+Default value: `false`
+
+Use `true` to ignore the recommended bump, and use the version provided by release-it (command line argument or prompt).
+
+Note that the changelog preview shows the recommended bump, as the desired version isn't known yet in the release-it
+process. The `infile` will have the correct version.
+
+### `strictSemVer`
+
+Default value: `false`
+
+Use `true` to strictly follow semver, also in consecutive pre-releases. This means that from a pre-release, a
+recommended bump will result in a next pre-release for the next version.
+
+For example, from `1.0.0-alpha.0` a recommended bump of `minor` will result in a `preminor` bump to `1.1.0-alpha.0`.
+
+The default behavior results in a `prerelease` bump to `1.0.0-alpha.1`.
+
+## Changelog
 
 ### `infile`
 
@@ -115,25 +159,6 @@ Set the main header for the changelog document:
   }
 }
 ```
-
-### `ignoreRecommendedBump`
-
-Default value: `false`
-
-Use `true` to ignore the recommended bump, and use the version provided by release-it (command line argument or prompt).
-
-(Note that the changelog preview shows the recommended bump, as the desired version isn't known yet. The `infile` will
-have the correct version.)
-
-### `strictSemVer`
-
-Default value: `false`
-
-Use `true` to strictly follow semver, also in consecutive pre-releases. This means that from a pre-release, a
-recommended bump will result in a next pre-release for the next version.
-
-For example, from `1.0.0-alpha.0` a recommended bump of `minor` will result in a `preminor` bump to `1.1.0-alpha.0`
-(whereas the default behavior without this flag results in a `prerelease` bump to `1.0.0-alpha.1`).
 
 ### `context`
 
@@ -175,10 +200,13 @@ For example, you can use the following option to include merge commits into chan
 
 ### `parserOpts`
 
-Default value: `undefined`
+- Default value: `undefined`
+- Options for
+  [`conventional-commits-parser`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#api)
+- This option will also be passed as the second argument to
+  [`bumper.parserOptions`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
+- [Type definition for `parserOpts` → look for `ParserOptions`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/src/types.ts)
 
-Options for
-[`conventional-commits-parser`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#api).
 For example, you can use the following option to set the merge pattern during parsing the commit message:
 
 ```json
@@ -195,10 +223,11 @@ For example, you can use the following option to set the merge pattern during pa
 
 ### `writerOpts`
 
-Default value: `undefined`
+- Default value: `undefined`
+- Options for
+  [`conventional-changelog-writer`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-writer#api)
+- [Type definition for `writerOpts` → look for `Options`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-writer/src/types/options.ts)
 
-Options for
-[`conventional-changelog-writer`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-writer#api).
 For example, you can use the following option to group the commits by 'scope' instead of 'type' by default.
 
 ```json
@@ -231,26 +260,6 @@ module.exports = {
   }
 };
 ```
-
-### `bumperTagOpts`
-
-This option will be passed as the first argument to
-[`bumper.tag`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
-
-### `bumperCommitsOpts`
-
-This option will be passed as the first argument to
-[`bumper.commits`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
-
-### `bumperParserOpts`
-
-This option will be passed as the second argument to
-[`bumper.parserOptions`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
-
-### `whatBump`
-
-This option will be passed as the first argument to
-[`bumper.bump`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
 
 ## Command-line
 

--- a/index.js
+++ b/index.js
@@ -41,9 +41,9 @@ class ConventionalChangelog extends Plugin {
 
       if (options.preset) bumper.loadPreset(options.preset);
 
-      if (options.bumperTagOpts) bumper.tag(options.bumperTagOpts);
+      if (options.tagOpts) bumper.tag(options.tagOpts);
 
-      if (options.bumperCommitsOpts) bumper.commits(options.bumperCommitsOpts, options.bumperParserOpts); // paramsOrCommits, parserOptions
+      if (options.commitsOpts) bumper.commits(options.commitsOpts, options.parserOpts);
 
       const result = await bumper.bump(options.whatBump);
 
@@ -71,7 +71,7 @@ class ConventionalChangelog extends Plugin {
           cwd: options.cwd
         });
 
-        bumper.tag({ ...options.bumperTagOpts, skipUnstable: true });
+        bumper.tag({ ...options.tagOpts, skipUnstable: true });
 
         const { releaseType: releaseTypeToLastNonPrerelease } = await bumper.bump(options.whatBump);
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "test": "bron test.js --serial",
+    "test": "node --test test.js",
     "release": "release-it"
   },
   "keywords": [
@@ -35,17 +35,16 @@
   },
   "dependencies": {
     "concat-stream": "^2.0.0",
-    "conventional-changelog": "^5.1.0",
-    "conventional-recommended-bump": "^9.0.0",
+    "conventional-changelog": "^6.0.0",
+    "conventional-recommended-bump": "^10.0.0",
     "git-semver-tags": "^8.0.0",
     "semver": "^7.6.3"
   },
   "devDependencies": {
-    "bron": "^2.0.3",
     "installed-check": "^9.3.0",
-    "release-it": "^17.6.0",
+    "release-it": "^17.7.0",
     "shelljs": "^0.8.5",
-    "sinon": "^18.0.1",
+    "sinon": "^19.0.2",
     "tmp": "^0.2.3"
   },
   "peerDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import test from 'bron';
+import test from 'node:test';
 import { strict as assert } from 'assert';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
So let's get this going, it was long overdue.

First of all, bigshout out to @FRSgit who made ball roll in #97. And since I totally agree the options in this plugin should as much be passed through verbatim, I followed up his PR with this one that does just that.

Would be great to get this started and hear your thoughts, API feedback, bugs, etc!

This is under development in the [v9 branch](https://github.com/release-it/conventional-changelog/tree/v9) and updated docs are at https://github.com/release-it/conventional-changelog/blob/v9/README.md

The latest version in this branch can be installed using the command as provided by the pkg-pr-new bot below (`npm i -D`).

cc @will-stone, @skycaptain, @juancarlosjr97, @ardakod, @timmywil, @Blackclaws, @ygrishajev, @Blackclaws

**NOTE:** I could use some help maintaining this plugin. The thing is, I don't really use it myself. So not to spam everyone too much again later on I'm bringing that in here as well. Free free to respond or DM me about this.