### PR TITLE
fix: Resolve whatBump is not a function error

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ for the configuration object to pass as `preset`.
 - This option will be passed as the first argument to
   [`bumper.bump`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
 - [Type definition for `whatBump` → look for `Preset['whatBump']`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/src/types.ts)
-- Use the `"undefined"` string value to skip releasing a new version.
+- Use the `false` Boolean value to skip releasing a new version.
 
 ```json
 {
   "plugins": {
     "@release-it/conventional-changelog": {
-      "whatBump": "undefined"
+      "whatBump": false
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ for the configuration object to pass as `preset`.
 - This option will be passed as the first argument to
   [`bumper.bump`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/README.md#api)
 - [Type definition for `whatBump` → look for `Preset['whatBump']`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/src/types.ts)
+- Use the `"undefined"` string value to skip releasing a new version.
+
+```json
+{
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "whatBump": "undefined"
+    }
+  }
+}
+```
 
 ### `ignoreRecommendedBump`
 

--- a/index.js
+++ b/index.js
@@ -65,10 +65,6 @@ class ConventionalChangelog extends Plugin {
 
       let { releaseType } = result;
 
-      if (releaseType == undefined) {
-        return;
-      }
-
       if (increment) {
         this.log.warn(`The recommended bump is "${releaseType}", but is overridden with "${increment}".`);
         releaseType = increment;

--- a/index.js
+++ b/index.js
@@ -53,9 +53,7 @@ class ConventionalChangelog extends Plugin {
 
           if (bumperPreset === null) return () => ({ releaseType: null });
 
-          const whatBump = bumperPreset.whatBump ? bumperPreset.whatBump : bumperPreset.recommendedBumpOpts.whatBump;
-
-          return whatBump;
+          return bumperPreset.whatBump || bumperPreset.recommendedBumpOpts.whatBump;
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ class ConventionalChangelog extends Plugin {
     try {
       const bumper = new Bumper();
 
-      if (options.preset) bumper.loadPreset(options.preset);
+      if (options.preset) await bumper.loadPreset(options.preset).preset;
 
       if (options.tagOpts) bumper.tag(options.tagOpts);
 
@@ -52,7 +52,7 @@ class ConventionalChangelog extends Plugin {
       let { releaseType } = result;
 
       if (releaseType == undefined) {
-         return;
+        return;
       }
 
       if (increment) {

--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ class ConventionalChangelog extends Plugin {
       if (options.commitsOpts) bumper.commits(options.commitsOpts, options.parserOpts);
 
       async function getWhatBump() {
-        if (options.whatBump === 'undefined') {
-          return () => ({ releaseType: undefined });
+        if (options.whatBump === false) {
+          return () => ({ releaseType: null });
         } else {
           const bumperPreset = await bumper.preset;
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,21 @@ class ConventionalChangelog extends Plugin {
 
       if (options.commitsOpts) bumper.commits(options.commitsOpts, options.parserOpts);
 
-      const result = await bumper.bump(options.whatBump);
+      async function getWhatBump() {
+        if (options.whatBump === 'undefined') {
+          return () => ({ releaseType: undefined });
+        } else {
+          const bumperPreset = await bumper.preset;
+
+          if (bumperPreset === null) return () => ({ releaseType: null });
+
+          const whatBump = bumperPreset.whatBump ? bumperPreset.whatBump : bumperPreset.recommendedBumpOpts.whatBump;
+
+          return whatBump;
+        }
+      }
+
+      const result = await bumper.bump(await getWhatBump());
 
       this.debug({ result });
 

--- a/test.js
+++ b/test.js
@@ -370,13 +370,13 @@ test('should not bump when recommended bump returns null', async () => {
   }
 });
 
-test('should not bump when whatBump === "undefined"', async () => {
+test('should not bump when whatBump === false', async () => {
   setup();
   sh.exec(`git tag 1.0.0`);
   add('fix', 'bar');
   add('feat', 'baz');
   {
-    const options = getOptions({ whatBump: 'undefined' });
+    const options = getOptions({ whatBump: false });
     const { version } = await runTasks(...options);
     assert.equal(version, undefined);
   }

--- a/test.js
+++ b/test.js
@@ -370,6 +370,18 @@ test('should not bump when recommended bump returns null', async () => {
   }
 });
 
+test('should not bump when whatBump === "undefined"', async () => {
+  setup();
+  sh.exec(`git tag 1.0.0`);
+  add('fix', 'bar');
+  add('feat', 'baz');
+  {
+    const options = getOptions({ whatBump: 'undefined' });
+    const { version } = await runTasks(...options);
+    assert.equal(version, undefined);
+  }
+});
+
 // TODO Prepare test and verify results influenced by parserOpts and writerOpts
 test.skip('should pass parserOpts and writerOpts', async t => {
   setup();


### PR DESCRIPTION
This PR does the following:
- Resolve the `ERROR whatBump is not a function` error by resolving the pending `preset` promise and passing the appropriate `whatBump` argument to `bumper.bump()`.
- Allow using any config file to optionally configure `release-it` to skip releasing a version. (Any accepted variation of a `whatBump: false` configuration option would do the job.

**`.release-it.json` Example**

```json
{
  "plugins": {
    "@release-it/conventional-changelog": {
      "preset": {
        "name": "conventionalcommits"
      },
      "whatBump": false
    }
  }
}
```

**`.release-it.js` Example**

```js
module.exports = {
  plugins: {
    "@release-it/conventional-changelog": {
      preset: {
        name: "conventionalcommits",
      },
      whatBump: false,
    }
  }
}
```

<details>
<summary><strong>Passing test's result</strong></summary>

```bash

$ npm run test

> @release-it/conventional-changelog@9.0.1 test
> node --test test.js

✔ should generate changelog using recommended bump (minor) (4839.2414ms)
✔ should generate changelog using recommended bump (patch) (2408.4955ms)
✔ should support tag suffix (2023.5232ms)
✔ should respect --no-increment and return previous, identical changelog (3402.4726ms)
✔ should ignore recommended bump (option) (2069.2052ms)
✔ should use provided pre-release id (1880.802ms)
- Git commit
✔ Git commit
- Git tag
✔ Git tag
- Git commit
✔ Git commit
- Git tag
✔ Git tag
- Git commit
✔ Git commit
- Git tag
✔ Git tag
- Git commit
✔ Git commit
- Git tag
✔ Git tag
✔ should follow conventional commit strategy with prereleaase (6971.9425ms)
✔ should use provided pre-release id (pre-release continuation) (1997.6218ms)
✔ should use provided pre-release id (next pre-release) (1672.1806ms)
✔ should use recommended bump (after pre-rerelease) (1865.4596ms)
✔ should follow strict semver (pre-release continuation) (1931.4418ms)
✔ should follow strict semver (pre-release continuation, conventionalcommits) (1892.9996ms)
✔ should use provided increment (1562.8889ms)
✔ should use provided version (ignore recommended bump) (1402.5338ms)
✔ should not throw with Git plugin disabled (886.8307ms)
- Git tag
✔ Git tag
✔ should write and update infile (4177.3786ms)
✔ should reject if conventional bump passes error (1171.7179ms)
✔ should reject if conventional changelog has error (1179.4039ms)
✔ should not write infile in dry run (1311.7151ms)
✔ should not write infile if set to false (1382.9401ms)
✔ should not bump when recommended bump returns null (4800.0704ms)
✔ should not bump when whatBump === false (2380.4874ms)
﹣ should pass parserOpts and writerOpts (0.1167ms) # SKIP
ℹ tests 23
ℹ suites 0
ℹ pass 22
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
ℹ duration_ms 55225.2853

```

</details>

Resolves #101, resolves #103 