### PR TITLE
fix: use whatBump option

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ class ConventionalChangelog extends Plugin {
       async function getWhatBump() {
         if (options.whatBump === false) {
           return () => ({ releaseType: null });
+        } else if (typeof options.whatBump === 'function') {
+          return options.whatBump;
         }
         const bumperPreset = await bumper.preset;
 

--- a/test.js
+++ b/test.js
@@ -384,11 +384,16 @@ test('should not bump when whatBump === false', async () => {
 
 test('should use given whatBump when provided',  async () => {
   setup();
+  sh.exec(`git tag 1.0.0`);
+  add('fix', 'bar');
   const whatBump = mock.fn()
   {
     const options = getOptions({ whatBump });
     await runTasks(...options);
     assert.ok(whatBump.mock.callCount() > 1)
+    const commitHeaders = whatBump.mock.calls[0].arguments[0]?.map((commit) => commit.header)
+    assert.strictEqual(commitHeaders.length, 1)
+    assert.match(commitHeaders[0], /^fix\(bar\):/)
   }
 });
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import {mock, test} from 'node:test';
 import { strict as assert } from 'assert';
 import fs from 'fs';
 import path from 'path';
@@ -379,6 +379,16 @@ test('should not bump when whatBump === false', async () => {
     const options = getOptions({ whatBump: false });
     const { version } = await runTasks(...options);
     assert.equal(version, undefined);
+  }
+});
+
+test('should use given whatBump when provided',  async () => {
+  setup();
+  const whatBump = mock.fn()
+  {
+    const options = getOptions({ whatBump });
+    await runTasks(...options);
+    assert.ok(whatBump.mock.callCount() > 1)
   }
 });
 


### PR DESCRIPTION
In #102 `whatBump` option was introduced to provide a custom way to recommend the version to bump. By passing it to `bumper.bump`. But if none was provided, then it failed. In #105 it was fixed so that if none is provided, the preset one is used. However now it's not used anymore if provided.

Fixing this by using the given `whatBump` in case it's a function. Done the TDD-way.

Btw found it curious conventional commits aren't used for this repo's commits. [_En casa de herrero, cuchara de palo_](https://english.stackexchange.com/questions/159004/the-cobblers-children-have-no-shoes) as we'd say in Spain 😛 
