### PR TITLE
Preserve preReleaseBase option for version increment

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,18 +23,24 @@ class ConventionalChangelog extends Plugin {
     if (!this.config.isIncrement) {
       this.setContext({ version: latestVersion });
     } else {
-      const { increment, isPreRelease, preReleaseId } = this.config.getContext('version');
-      const version = await this.getRecommendedVersion({ increment, latestVersion, isPreRelease, preReleaseId });
+      const { increment, isPreRelease, preReleaseId, preReleaseBase } = this.config.getContext('version');
+      const version = await this.getRecommendedVersion({
+        increment,
+        latestVersion,
+        isPreRelease,
+        preReleaseId,
+        preReleaseBase
+      });
       this.setContext({ version });
     }
     return this.generateChangelog();
   }
 
-  async getRecommendedVersion({ increment, latestVersion, isPreRelease, preReleaseId }) {
+  async getRecommendedVersion({ increment, latestVersion, isPreRelease, preReleaseId, preReleaseBase }) {
     const { version } = this.getContext();
     if (version) return version;
     const { options } = this;
-    this.debug({ increment, latestVersion, isPreRelease, preReleaseId });
+    this.debug({ increment, latestVersion, isPreRelease, preReleaseId, preReleaseBase });
     this.debug('conventionalRecommendedBump', { options });
     try {
       const bumper = new Bumper();
@@ -75,7 +81,7 @@ class ConventionalChangelog extends Plugin {
 
       if (isPreRelease) {
         if (releaseType && (options.strictSemVer || !semver.prerelease(latestVersion))) {
-          return semver.inc(latestVersion, `pre${releaseType}`, preReleaseId);
+          return semver.inc(latestVersion, `pre${releaseType}`, preReleaseId, preReleaseBase);
         }
 
         const tags = await getSemverTags({
@@ -102,15 +108,15 @@ class ConventionalChangelog extends Plugin {
             semver[releaseTypeToLastNonPrerelease](lastStableTag) ==
             semver[releaseTypeToLastNonPrerelease](latestVersion)
           ) {
-            return semver.inc(latestVersion, `pre${releaseTypeToLastNonPrerelease}`, preReleaseId);
+            return semver.inc(latestVersion, `pre${releaseTypeToLastNonPrerelease}`, preReleaseId, preReleaseBase);
           }
         }
 
-        return semver.inc(latestVersion, 'prerelease', preReleaseId);
+        return semver.inc(latestVersion, 'prerelease', preReleaseId, preReleaseBase);
       }
 
       if (releaseType) {
-        return semver.inc(latestVersion, releaseType, preReleaseId);
+        return semver.inc(latestVersion, releaseType, preReleaseId, preReleaseBase);
       }
 
       return null;

--- a/test.js
+++ b/test.js
@@ -163,6 +163,18 @@ test('should use provided pre-release id', async t => {
   assert.equal(version, '1.1.0-alpha.0');
 });
 
+test('should use provided pre-release base', async t => {
+  setup();
+  sh.exec(`git tag 1.0.0`);
+  add('feat', 'baz');
+
+  const [config, container] = getOptions({ preset });
+  config.preRelease = 'alpha';
+  config.preReleaseBase = '1';
+  const { version } = await runTasks(config, container);
+  assert.equal(version, '1.1.0-alpha.1');
+});
+
 test('should follow conventional commit strategy with prereleaase', async t => {
   setup();
   sh.exec(`git tag 1.2.1`);


### PR DESCRIPTION
In [release-it/#1128](https://github.com/release-it/release-it/issues/1128) a new config option `preReleaseBase` was introduced. I think it would be useful to use this option in this plugin, similar to how it is used in the core `Version` plugin.