### PR TITLE
fix: fixed release for no preset case

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,8 +96,14 @@ class ConventionalChangelog extends Plugin {
       } else if (typeof options.whatBump === 'function') {
         whatBumpFn = options.whatBump;
       } else {
-        // Use the whatBump from the loaded preset
-        whatBumpFn = bumper.whatBump;
+        const bumperPreset = await bumper.preset;
+
+        if (!bumperPreset) {
+          whatBumpFn = () => ({ releaseType: null });
+        } else {
+          // Use the whatBump from the loaded preset (stored in bumper.whatBump)
+          whatBumpFn = bumper.whatBump;
+        }
       }
 
       const recommendation = await bumper.bump(whatBumpFn);


### PR DESCRIPTION
Fixed the issue when a `release-it` doesn't work as expected.

Currently, it fails when trying to access a non-existent `whatBump` function from the `config`. https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/src/bumper.ts#L132

See https://github.com/release-it/conventional-changelog/issues/126 for details.