### PR TITLE
fix: remove preset options filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,7 @@ function conventionalChangelog(options = {}, context = {}, gitRawCommitsOpts = {
   const generator = new ConventionalChangelogGenerator(options.cwd || process.cwd());
 
   if (options.preset) {
-    if (typeof options.preset === 'string') {
-      generator.loadPreset(options.preset);
-    } else if (typeof options.preset === 'object' && options.preset.name) {
-      generator.loadPreset(options.preset.name);
-    }
+    generator.loadPreset(options.preset);
   }
 
   if (options.releaseCount !== undefined || options.append !== undefined) {


### PR DESCRIPTION
- fixes issue with preset types not being passed when `options.preset === 'object'`
Custom section names, visibility options, etc are now passed and written to changelog
Previously only name was passed so 'string' and 'object' paths were identical

- simplify to thin wrapper (remove duplicate conditional)
`conventional-changelog`'s `createPresetLoader()` already does:
```js
    if (typeof presetOrParams === 'string') {
      preset = presetOrParams
    } else
      if (typeof presetOrParams === 'object' && typeof presetOrParams.name === 'string') {
        preset = presetOrParams.name
        params = presetOrParams
      } else {
        throw Error('Preset must be string or object with property `name`')
      }
```

Tested manually & all other tests continue to pass