### PR TITLE
fix: add readRepository to resolve correct urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,13 @@ import semver from 'semver';
 import concat from 'concat-stream';
 
 // Wrapper function to provide backward compatibility with the old API
-function conventionalChangelog(options = {}, context = {}, gitRawCommitsOpts = {}, parserOpts = {}, writerOpts = {}) {
+async function conventionalChangelog(
+  options = {},
+  context = {},
+  gitRawCommitsOpts = {},
+  parserOpts = {},
+  writerOpts = {}
+) {
   const generator = new ConventionalChangelogGenerator(options.cwd || process.cwd());
 
   if (options.preset) {
@@ -39,11 +45,10 @@ function conventionalChangelog(options = {}, context = {}, gitRawCommitsOpts = {
     generator.writer(writerOpts);
   }
 
-  generator.gitClient.getConfig('remote.origin.url').then(() => {
+  try {
+    await generator.gitClient.getConfig('remote.origin.url');
     generator.readRepository();
-  }).catch(() => {
-    // remote.origin.url is not set => continue without reading repository
-  })
+  } catch {}
 
   return generator.writeStream();
 }
@@ -196,9 +201,10 @@ class ConventionalChangelog extends Plugin {
   generateChangelog(options) {
     return new Promise((resolve, reject) => {
       const resolver = result => resolve(result.toString().trim());
-      const changelogStream = this.getChangelogStream(options);
-      changelogStream.pipe(concat(resolver));
-      changelogStream.on('error', reject);
+      this.getChangelogStream(options).then(changelogStream => {
+        changelogStream.pipe(concat(resolver));
+        changelogStream.on('error', reject);
+      });
     });
   }
 


### PR DESCRIPTION
## Problem

With changing to conventional-changelog v7 the API changed. The changelogs were incorrect since that PR (#124)

```
Changelog:
## [1.0.0](///compare/v1.0.0...v1.0.1) (2025-12-15)

### 📝 Documentation

* one doc commit ([#154](undefined/undefined/undefined/issues/154)) c5da15c

### 🚧 Chores

* one chore commit ([#153](undefined/undefined/undefined/issues/153)) 4914713
```
Relates to #128

## Fix
With reading the repository the urls are determined correctly.

With this fix #124 should be solved entirely. The first step for it was #129