### PR TITLE
fix: handle missing preset without accessing Bumper internals

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,17 +94,19 @@ class ConventionalChangelog extends Plugin {
         bumper.commits(options.commitsOpts || {}, options.parserOpts);
       }
 
+      const noBump = () => ({ releaseType: null });
       let whatBumpFn;
       if (options.whatBump === false) {
-        whatBumpFn = () => ({ releaseType: null });
+        whatBumpFn = noBump;
       } else if (typeof options.whatBump === 'function') {
         whatBumpFn = options.whatBump;
-      } else {
-        // Use the whatBump from the loaded preset
-        whatBumpFn = bumper.whatBump;
+      } else if (!options.preset) {
+        whatBumpFn = noBump;
       }
 
-      const recommendation = await bumper.bump(whatBumpFn);
+      const recommendation = whatBumpFn
+        ? await bumper.bump(whatBumpFn)
+        : await bumper.bump();
 
       this.debug({ result: recommendation });
 
@@ -137,7 +139,9 @@ class ConventionalChangelog extends Plugin {
 
         bumper.tag({ ...options.tagOpts, skipUnstable: true });
 
-        const { releaseType: releaseTypeToLastNonPrerelease } = await bumper.bump(whatBumpFn);
+        const { releaseType: releaseTypeToLastNonPrerelease } = whatBumpFn
+          ? await bumper.bump(whatBumpFn)
+          : await bumper.bump();
 
         const lastStableTag = tags.length > 0 ? tags[0] : null;
 

--- a/test.js
+++ b/test.js
@@ -398,6 +398,16 @@ test('should not bump when whatBump === false', async () => {
   }
 });
 
+test('should not throw when no preset provided', async () => {
+  setup();
+  sh.exec(`git tag 1.0.0`);
+  add('fix', 'bar');
+
+  const options = getOptions({});
+  const { version } = await runTasks(...options);
+  assert.equal(version, undefined);
+});
+
 test('should use given whatBump when provided', async () => {
   setup();
   sh.exec(`git tag 1.0.0`);


### PR DESCRIPTION
## Summary

- Fix `whatBump must be a function` error when no preset is configured
- Avoid accessing internal `bumper.whatBump` property
- When a preset is loaded, let `bumper.bump()` use its internal whatBump
- When no preset is loaded and no whatBump provided, use a noBump fallback

## Root Cause

The CVE fix (c838c67) changed the code to access `bumper.whatBump` directly, which is `null` when no preset is loaded, causing the error.

## Test plan

- [x] Added test case for no preset scenario
- [x] All 28 existing tests pass

Fixes #107