### PR TITLE
fix: bump conventional-changelog to ^7.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@conventional-changelog/git-client": "^2.5.1",
         "concat-stream": "^2.0.0",
-        "conventional-changelog": "^7.1.1",
+        "conventional-changelog": "^7.2.0",
         "conventional-changelog-angular": "^8.1.0",
         "conventional-changelog-conventionalcommits": "^9.1.0",
         "conventional-recommended-bump": "^11.2.0",
@@ -123,13 +123,13 @@
       }
     },
     "node_modules/@conventional-changelog/git-client": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.5.1.tgz",
-      "integrity": "sha512-lAw7iA5oTPWOLjiweb7DlGEMDEvzqzLLa6aWOly2FSZ64IwLE8T458rC+o+WvI31Doz6joM7X2DoNog7mX8r4A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.6.0.tgz",
+      "integrity": "sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==",
       "license": "MIT",
       "dependencies": {
         "@simple-libs/child-process-utils": "^1.0.0",
-        "@simple-libs/stream-utils": "^1.1.0",
+        "@simple-libs/stream-utils": "^1.2.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -137,7 +137,7 @@
       },
       "peerDependencies": {
         "conventional-commits-filter": "^5.0.0",
-        "conventional-commits-parser": "^6.1.0"
+        "conventional-commits-parser": "^6.3.0"
       },
       "peerDependenciesMeta": {
         "conventional-commits-filter": {
@@ -974,14 +974,23 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/@simple-libs/stream-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.1.0.tgz",
-      "integrity": "sha512-6rsHTjodIn/t90lv5snQjRPVtOosM7Vp0AKdrObymq45ojlgVwnpAqdc+0OBBrpEiy31zZ6/TKeIVqV1HwvnuQ==",
+    "node_modules/@simple-libs/hosted-git-info": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-1.0.2.tgz",
+      "integrity": "sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg==",
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "^22.0.0"
+      "engines": {
+        "node": ">=18"
       },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1437,16 +1446,17 @@
       }
     },
     "node_modules/conventional-changelog": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.1.1.tgz",
-      "integrity": "sha512-rlqa8Lgh8YzT3Akruk05DR79j5gN9NCglHtJZwpi6vxVeaoagz+84UAtKQj/sT+RsfGaZkt3cdFCjcN6yjr5sw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.2.0.tgz",
+      "integrity": "sha512-BEdgG+vPl53EVlTTk9sZ96aagFp0AQ5pw/ggiQMy2SClLbTo1r0l+8dSg79gkLOO5DS1Lswuhp5fWn6RwE+ivg==",
       "license": "MIT",
       "dependencies": {
-        "@conventional-changelog/git-client": "^2.5.1",
+        "@conventional-changelog/git-client": "^2.6.0",
+        "@simple-libs/hosted-git-info": "^1.0.2",
         "@types/normalize-package-data": "^2.4.4",
         "conventional-changelog-preset-loader": "^5.0.0",
-        "conventional-changelog-writer": "^8.2.0",
-        "conventional-commits-parser": "^6.2.0",
+        "conventional-changelog-writer": "^8.3.0",
+        "conventional-commits-parser": "^6.3.0",
         "fd-package-json": "^2.0.0",
         "meow": "^13.0.0",
         "normalize-package-data": "^7.0.0"
@@ -1492,11 +1502,12 @@
       }
     },
     "node_modules/conventional-changelog-writer": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
-      "integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+      "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
       "license": "MIT",
       "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
         "conventional-commits-filter": "^5.0.0",
         "handlebars": "^4.7.7",
         "meow": "^13.0.0",
@@ -1569,11 +1580,12 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
-      "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
+      "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
       "license": "MIT",
       "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
         "meow": "^13.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@conventional-changelog/git-client": "^2.5.1",
     "concat-stream": "^2.0.0",
-    "conventional-changelog": "^7.1.1",
+    "conventional-changelog": "^7.2.0",
     "conventional-changelog-angular": "^8.1.0",
     "conventional-changelog-conventionalcommits": "^9.1.0",
     "conventional-recommended-bump": "^11.2.0",


### PR DESCRIPTION
## Summary

- Bumps `conventional-changelog` from `^7.1.1` to `^7.2.0`
- Fixes incorrect changelog URLs for GitLab repos with nested subgroups (3+ path segments), where the project name was dropped from generated compare and commit links

The root cause was in the upstream `parseHostedGitUrl` regex which only supported at most 2 owner path segments. This was fixed in [conventional-changelog/conventional-changelog#1429](https://github.com/conventional-changelog/conventional-changelog/pull/1429) and released in `conventional-changelog@7.2.0`.

Closes #140

## Test plan

- [x] All existing tests pass
- [x] Verified `parseHostedGitUrl` now correctly parses nested subgroup URLs (e.g. `https://gitlab.com/sub/group/path/project-name.git` → owner: `sub/group/path`, project: `project-name`)